### PR TITLE
Invalid resource name for models nested in module

### DIFF
--- a/lib/optimism.rb
+++ b/lib/optimism.rb
@@ -26,7 +26,7 @@ module Optimism
 
   def broadcast_errors(model, attributes)
     return unless model&.errors&.messages
-    resource = model.class.to_s.underscore
+    resource = ActiveModel::Naming.param_key(model)
     form_selector, submit_selector = Optimism.form_selector.sub("RESOURCE", resource), Optimism.submit_selector.sub("RESOURCE", resource)
     attributes = case attributes
     when ActionController::Parameters, Hash, ActiveSupport::HashWithIndifferentAccess


### PR DESCRIPTION
## Bug

The selectors send in the JSON over action cable are not the same that the one generated by the the form helper for models nested in module.

## Example

In my example I have a Webhook model inside a Triggers module.

From rails console:
```ruby
a = Triggers::Webhook.create()
 => ...
a.class.to_s.underscore
 => "triggers/webhook" 
```

It matches the selectors I saw in the JSON paylod:
```
"selector"=>"#triggers/webhook_title_container"
```

This payload has 2 issues:
1. Strings with `/` are not recognized by `document.querySelector` as valid css selectors
2. These selectors are not the same as the one generated by the form helper

Still in my example it is what I have in my HTML:
```html
<input name="triggers_webhook[title]" id="triggers_webhook_title_container"/>
```

As you can see id is not the same as the generated selector.

## Solution

Use the same function as the rails form_helper to compute the correct name. 
https://github.com/rails/rails/blob/98ddee2b6e3e4da5ad84dcc1313493b04935711b/actionview/lib/action_view/helpers/form_helper.rb#L442

I'm a newbie in Rails so maybe it is not the right way fix this issue. Please do not hesitate to improve my solution 😄 .

