### PR TITLE
restructuring syntax for rails 6.1 compatibility

### DIFF
--- a/lib/optimism.rb
+++ b/lib/optimism.rb
@@ -4,21 +4,21 @@ require "optimism/railtie" if defined?(Rails)
 
 module Optimism
   include CableReady::Broadcaster
-  class << self
-    mattr_accessor :channel, :form_class, :error_class, :disable_submit, :suffix, :emit_events, :add_css, :inject_inline, :container_selector, :error_selector, :form_selector, :submit_selector
-    self.channel = ->(context) { "OptimismChannel" }
-    self.form_class = "invalid"
-    self.error_class = "error"
-    self.disable_submit = false
-    self.suffix = ""
-    self.emit_events = false
-    self.add_css = true
-    self.inject_inline = true
-    self.container_selector = "#RESOURCE_ATTRIBUTE_container"
-    self.error_selector = "#RESOURCE_ATTRIBUTE_error"
-    self.form_selector = "#RESOURCE_form"
-    self.submit_selector = "#RESOURCE_submit"
-  end
+
+  mattr_accessor :channel, :form_class, :error_class, :disable_submit, :suffix, :emit_events, :add_css, :inject_inline, :container_selector, :error_selector, :form_selector, :submit_selector
+
+  self.channel = ->(context) { "OptimismChannel" }
+  self.form_class = "invalid"
+  self.error_class = "error"
+  self.disable_submit = false
+  self.suffix = ""
+  self.emit_events = false
+  self.add_css = true
+  self.inject_inline = true
+  self.container_selector = "#RESOURCE_ATTRIBUTE_container"
+  self.error_selector = "#RESOURCE_ATTRIBUTE_error"
+  self.form_selector = "#RESOURCE_form"
+  self.submit_selector = "#RESOURCE_submit"
 
   def self.configure(&block)
     yield self


### PR DESCRIPTION
Rails 6.1 is introducing a check to verify if the class is the class is not a Singleton, and if it is raises a TypeError.
This PR simply changes the structure of the code and instead of calling `mattr_accessor` in the singleton class, simply calls it on the module. Making it ready for 6.1 or whoever is using the edge version of Rails.